### PR TITLE
Update to changes in containers/image APIs

### DIFF
--- a/libpod/images/copy_ref.go
+++ b/libpod/images/copy_ref.go
@@ -59,34 +59,17 @@ type copySource struct {
 
 // NewImage creates a new image from the given system context
 func (c *CopyRef) NewImage(sc *types.SystemContext) (types.Image, error) {
-	src, err := c.NewImageSource(sc, nil)
+	src, err := c.NewImageSource(sc)
 	if err != nil {
 		return nil, err
 	}
 	return image.FromSource(src)
 }
 
-func selectManifestType(preferred string, acceptable, supported []string) string {
-	selected := preferred
-	for _, accept := range acceptable {
-		if preferred == accept {
-			return preferred
-		}
-		for _, support := range supported {
-			if accept == support {
-				selected = accept
-			}
-		}
-	}
-	return selected
-}
-
 // NewImageSource creates a new image source from the given system context and manifest
-func (c *CopyRef) NewImageSource(sc *types.SystemContext, manifestTypes []string) (src types.ImageSource, err error) {
-	// Decide which type of manifest and configuration output we're going to provide.
-	supportedManifestTypes := []string{v1.MediaTypeImageManifest, docker.V2S2MediaTypeManifest}
-	manifestType := selectManifestType(c.preferredManifestType, manifestTypes, supportedManifestTypes)
-	// If it's not a format we support, return an error.
+func (c *CopyRef) NewImageSource(sc *types.SystemContext) (src types.ImageSource, err error) {
+	// Try to provide a manifest and configuration in the same format the current ones are in.
+	manifestType := c.preferredManifestType
 	if manifestType != v1.MediaTypeImageManifest && manifestType != docker.V2S2MediaTypeManifest {
 		return nil, errors.Errorf("no supported manifest types (attempted to use %q, only know %q and %q)",
 			manifestType, v1.MediaTypeImageManifest, docker.V2S2MediaTypeManifest)

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -169,7 +169,7 @@ func (svc *imageService) CanPull(imageName string, options *copy.Options) (bool,
 	if err != nil {
 		return false, err
 	}
-	rawSource, err := srcRef.NewImageSource(options.SourceCtx, nil)
+	rawSource, err := srcRef.NewImageSource(options.SourceCtx)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The ImageReference.NewImageSource() method no longer takes a list of manifest MIME types, so we don't need to be passing one in, and we don't get one in our own implementation.